### PR TITLE
ui: auto-detect dark/light terminal background for theming

### DIFF
--- a/autocomplete.go
+++ b/autocomplete.go
@@ -235,9 +235,9 @@ func (m *model) viewAutocomplete() string {
 	widths := make([]int, len(m.acSuggestions))
 	for i, s := range m.acSuggestions {
 		if i == m.acIndex {
-			rendered[i] = acSelectedStyle.Render(s)
+			rendered[i] = m.theme.ACSelected.Render(s)
 		} else {
-			rendered[i] = acSuggestionStyle.Render(s)
+			rendered[i] = m.theme.ACSuggestion.Render(s)
 		}
 		widths[i] = lipgloss.Width(rendered[i])
 	}
@@ -245,7 +245,7 @@ func (m *model) viewAutocomplete() string {
 	// Find a window of items that fits within maxWidth, ensuring the
 	// selected item is always visible.  Reserve space for the left/right
 	// scroll indicators so they don't push the output past maxWidth.
-	indicatorW := lipgloss.Width(acSuggestionStyle.Render("▸"))
+	indicatorW := lipgloss.Width(m.theme.ACSuggestion.Render("▸"))
 	start := m.acIndex
 	end := m.acIndex + 1
 	used := widths[m.acIndex]
@@ -288,11 +288,11 @@ func (m *model) viewAutocomplete() string {
 
 	var parts []string
 	if start > 0 {
-		parts = append(parts, acSuggestionStyle.Render("◂"))
+		parts = append(parts, m.theme.ACSuggestion.Render("◂"))
 	}
 	parts = append(parts, rendered[start:end]...)
 	if end < len(m.acSuggestions) {
-		parts = append(parts, acSuggestionStyle.Render("▸"))
+		parts = append(parts, m.theme.ACSuggestion.Render("▸"))
 	}
 
 	return lipgloss.JoinHorizontal(lipgloss.Top, parts...)

--- a/commands.go
+++ b/commands.go
@@ -42,7 +42,7 @@ func (m *model) handleCommand(text string) (tea.Model, tea.Cmd) {
 		return m.openDM(arg)
 
 	case "/me":
-		m.qrOverlay = renderQR("Your npub:", "nostr:"+m.keys.NPub)
+		m.qrOverlay = m.renderQR("Your npub:", "nostr:"+m.keys.NPub)
 		return m, nil
 
 	case "/room":
@@ -55,7 +55,7 @@ func (m *model) handleCommand(text string) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 				nevent := nip19.EncodeNevent(id, m.relays, nostr.PubKey{})
-				m.qrOverlay = renderQR("#"+it.Channel.Name, "nostr:"+nevent)
+				m.qrOverlay = m.renderQR("#"+it.Channel.Name, "nostr:"+nevent)
 				return m, nil
 			case GroupItem:
 				naddr, err := m.groupNaddr(it.Group)
@@ -63,7 +63,7 @@ func (m *model) handleCommand(text string) (tea.Model, tea.Cmd) {
 					m.addSystemMsg(fmt.Sprintf("encode error: %v", err))
 					return m, nil
 				}
-				m.qrOverlay = renderQR("~"+it.Group.Name, "nostr:"+naddr)
+				m.qrOverlay = m.renderQR("~"+it.Group.Name, "nostr:"+naddr)
 				return m, nil
 			}
 		}

--- a/config.example.toml
+++ b/config.example.toml
@@ -16,6 +16,11 @@ private_key_file = "~/.config/nitrous/nsec"
 
 max_messages = 500
 
+# Theme: "auto" (detect terminal background), "dark", or "light".
+# Default is auto-detection. Override if detection gives wrong results
+# (e.g. inside tmux or over SSH).
+# theme = "auto"
+
 # Message logging — plain-text chat logs, one file per room.
 # Enabled by default. Set to false to disable.
 # logging = true

--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	MaxMessages    int           `toml:"max_messages"`
 	Logging        *bool         `toml:"logging"`        // nil = default (true)
 	LogDir         string        `toml:"log_dir"`
+	Theme          string        `toml:"theme"`          // "auto", "dark", "light"; empty = "auto"
 	Profile        ProfileConfig `toml:"profile"`
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -22,10 +22,9 @@ import (
 	"fiatjaf.com/nostr/nip19"
 )
 
-func init() {
-	// Ensure author colors are initialised even without a real terminal.
-	authorColors = authorColorsDark
-}
+// testTheme provides a pre-built dark theme for integration tests
+// so they don't need terminal background detection.
+var testTheme = buildTheme(true)
 
 // isNIP29Kind returns true for kinds managed by relay29 (group messages, moderation, metadata).
 func isNIP29Kind(kind int) bool {
@@ -231,7 +230,7 @@ func newTestClient(t *testing.T, name string, relayURL string) *testClient {
 		},
 	})
 
-	m := newModel(cfg, "", keys, pool, &kr, nil, "")
+	m := newModel(cfg, "", keys, pool, &kr, nil, testTheme)
 
 	tm := teatest.NewTestModel(t, &m,
 		teatest.WithInitialTermSize(120, 40),

--- a/main.go
+++ b/main.go
@@ -71,12 +71,10 @@ func main() {
 	}
 	log.Printf("keys loaded: npub=%s", keys.NPub)
 
-	// Create the markdown renderer before the TUI starts so the terminal
+	// Resolve theme (dark/light) before the TUI starts so the terminal
 	// background-color query (OSC 11) completes while stdio is still normal.
-	// Detect style once, store it for re-creation on resize.
-	mdStyle := detectGlamourStyle()
-	initAuthorColors()
-	mdRender := newMarkdownRenderer(mdStyle)
+	theme := resolveTheme(cfg)
+	mdRender := newMarkdownRenderer(theme.GlamourStyle)
 
 	kr := keyer.NewPlainKeySigner(keys.SK)
 
@@ -87,7 +85,7 @@ func main() {
 		},
 	})
 
-	m := newModel(cfg, *configFlag, keys, pool, &kr, mdRender, mdStyle)
+	m := newModel(cfg, *configFlag, keys, pool, &kr, mdRender, theme)
 
 	log.Println("starting TUI")
 	p := tea.NewProgram(&m, tea.WithAltScreen(), tea.WithMouseCellMotion())

--- a/model.go
+++ b/model.go
@@ -27,6 +27,9 @@ type Group struct {
 }
 
 type model struct {
+	// Theme (dark/light colours and styles)
+	theme Theme
+
 	// Config and keys
 	cfg         Config
 	cfgFlagPath string
@@ -63,7 +66,6 @@ type model struct {
 	viewport viewport.Model
 	input    textarea.Model
 	mdRender *glamour.TermRenderer
-	mdStyle  string
 
 	// Global messages (shown when no channel/DM is active)
 	globalMsgs []ChatMessage
@@ -217,7 +219,7 @@ func (m *model) activeSidebarItem() SidebarItem {
 
 
 
-func newModel(cfg Config, cfgFlagPath string, keys Keys, pool *nostr.Pool, kr nostr.Keyer, mdRender *glamour.TermRenderer, mdStyle string) model {
+func newModel(cfg Config, cfgFlagPath string, keys Keys, pool *nostr.Pool, kr nostr.Keyer, mdRender *glamour.TermRenderer, theme Theme) model {
 	ta := textarea.New()
 	ta.Placeholder = "Type a message... (/help for commands)"
 	ta.Prompt = "> "
@@ -257,6 +259,7 @@ func newModel(cfg Config, cfgFlagPath string, keys Keys, pool *nostr.Pool, kr no
 	}
 
 	return model{
+		theme:       theme,
 		cfg:         cfg,
 		cfgFlagPath: cfgFlagPath,
 		keys:        keys,
@@ -282,7 +285,6 @@ func newModel(cfg Config, cfgFlagPath string, keys Keys, pool *nostr.Pool, kr no
 		viewport:       vp,
 		input:          ta,
 		mdRender:       mdRender,
-		mdStyle:        mdStyle,
 		statusMsg:      fmt.Sprintf("connected to %d relays", len(cfg.Relays)),
 		logDir:         logDir,
 	}
@@ -433,9 +435,9 @@ func (m *model) loadHistory(roomType, roomKey string) []string {
 }
 
 // renderQR renders a QR code with a title line above it.
-func renderQR(title, content string) string {
+func (m *model) renderQR(title, content string) string {
 	var buf strings.Builder
-	buf.WriteString(qrTitleStyle.Render(title))
+	buf.WriteString(m.theme.QRTitle.Render(title))
 	buf.WriteString("\n\n")
 	qrterminal.GenerateWithConfig(content, qrterminal.Config{
 		Level:          qrterminal.M,
@@ -448,6 +450,6 @@ func renderQR(title, content string) string {
 		QuietZone:      1,
 	})
 	buf.WriteString("\n")
-	buf.WriteString(chatSystemStyle.Render(content))
+	buf.WriteString(m.theme.ChatSystem.Render(content))
 	return buf.String()
 }

--- a/selection.go
+++ b/selection.go
@@ -11,9 +11,6 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-// selectionStyle applies reverse video for selection highlighting.
-var selectionStyle = lipgloss.NewStyle().Reverse(true)
-
 // applySelectionHighlight overlays reverse-video on the selected region
 // of the viewport output.
 func (m *model) applySelectionHighlight(vp string) string {
@@ -54,7 +51,7 @@ func (m *model) applySelectionHighlight(vp string) string {
 		}
 		// Rebuild line: prefix + highlighted + suffix (using plain text
 		// to avoid ANSI nesting issues).
-		vpLines[y] = plain[:from] + selectionStyle.Render(plain[from:to]) + plain[to:]
+		vpLines[y] = plain[:from] + m.theme.Selection.Render(plain[from:to]) + plain[to:]
 	}
 	return strings.Join(vpLines, "\n")
 }

--- a/ui.go
+++ b/ui.go
@@ -8,67 +8,180 @@ import (
 	"github.com/muesli/termenv"
 )
 
-// Colors
-var (
-	colorPrimary   = lipgloss.Color("#7B68EE")
-	colorSecondary = lipgloss.Color("#5B5682")
-	colorMuted     = lipgloss.Color("#636363")
-	colorHighlight = lipgloss.Color("#E0DAFF")
-	colorStatusBg  = lipgloss.Color("#24283B")
-	colorWhite     = lipgloss.Color("#C0CAF5")
-	colorGreen     = lipgloss.Color("#9ECE6A")
-)
+// Theme bundles all colour values and pre-built lipgloss styles for the UI.
+// A single Theme instance is stored on the model and threaded through all
+// rendering code, replacing the former package-level style variables.
+type Theme struct {
+	// Colour roles
+	Primary   lipgloss.Color
+	Secondary lipgloss.Color
+	Muted     lipgloss.Color
+	Highlight lipgloss.Color
+	StatusBg  lipgloss.Color
+	Text      lipgloss.Color
+	Success   lipgloss.Color
 
-// Distinct author colors — chosen for readability on dark backgrounds.
-var authorColorsDark = []lipgloss.Color{
-	"#7B68EE", // medium slate blue
-	"#FF6B6B", // coral red
-	"#4ECDC4", // teal
-	"#FFD93D", // gold
-	"#C084FC", // violet
-	"#FF8C42", // orange
-	"#6BCB77", // green
-	"#4D96FF", // blue
-	"#FF6EC7", // hot pink
-	"#00D2FF", // cyan
-	"#E879F9", // fuchsia
-	"#A3E635", // lime
+	// Pre-built styles
+	Sidebar         lipgloss.Style
+	SidebarItem     lipgloss.Style
+	SidebarUnread   lipgloss.Style
+	SidebarSelected lipgloss.Style
+	SidebarSection  lipgloss.Style
+	ChatAuthor      lipgloss.Style
+	ChatOwnAuthor   lipgloss.Style
+	ChatTimestamp   lipgloss.Style
+	StatusBar       lipgloss.Style
+	StatusConnected lipgloss.Style
+	ChatSystem      lipgloss.Style
+	QRTitle         lipgloss.Style
+	ACSuggestion    lipgloss.Style
+	ACSelected      lipgloss.Style
+	Selection       lipgloss.Style
+
+	// Author colour palette for per-pubkey colouring.
+	AuthorColors []lipgloss.Color
+
+	// Glamour markdown renderer style ("dark" or "light").
+	GlamourStyle string
 }
 
-// Distinct author colors — chosen for readability on light backgrounds.
-var authorColorsLight = []lipgloss.Color{
-	"#4B38AE", // deep slate blue
-	"#C0392B", // dark red
-	"#1A8A7D", // dark teal
-	"#B8860B", // dark goldenrod
-	"#7B2D8E", // dark violet
-	"#C0561A", // dark orange
-	"#2E7D32", // dark green
-	"#1A5DB0", // dark blue
-	"#B03060", // dark pink
-	"#007A99", // dark cyan
-	"#9B30FF", // dark fuchsia
-	"#558B2F", // dark lime
-}
-
-// authorColors is set at init time based on terminal background.
-var authorColors []lipgloss.Color
-
-// initAuthorColors selects the author color palette based on terminal background.
-// Must be called before the TUI starts (e.g., alongside detectGlamourStyle).
-func initAuthorColors() {
-	if termenv.HasDarkBackground() {
-		authorColors = authorColorsDark
+// buildTheme constructs a fully populated Theme for dark or light backgrounds.
+func buildTheme(isDark bool) Theme {
+	var t Theme
+	if isDark {
+		t.Primary = lipgloss.Color("#7B68EE")
+		t.Secondary = lipgloss.Color("#5B5682")
+		t.Muted = lipgloss.Color("#636363")
+		t.Highlight = lipgloss.Color("#E0DAFF")
+		t.StatusBg = lipgloss.Color("#24283B")
+		t.Text = lipgloss.Color("#C0CAF5")
+		t.Success = lipgloss.Color("#9ECE6A")
+		t.AuthorColors = []lipgloss.Color{
+			"#7B68EE", // medium slate blue
+			"#FF6B6B", // coral red
+			"#4ECDC4", // teal
+			"#FFD93D", // gold
+			"#C084FC", // violet
+			"#FF8C42", // orange
+			"#6BCB77", // green
+			"#4D96FF", // blue
+			"#FF6EC7", // hot pink
+			"#00D2FF", // cyan
+			"#E879F9", // fuchsia
+			"#A3E635", // lime
+		}
+		t.GlamourStyle = "dark"
 	} else {
-		authorColors = authorColorsLight
+		t.Primary = lipgloss.Color("#4B38AE")
+		t.Secondary = lipgloss.Color("#B8B0D8")
+		t.Muted = lipgloss.Color("#7A7A7A")
+		t.Highlight = lipgloss.Color("#3B2E8A")
+		t.StatusBg = lipgloss.Color("#E8E4F0")
+		t.Text = lipgloss.Color("#2E2E3E")
+		t.Success = lipgloss.Color("#2E7D32")
+		t.AuthorColors = []lipgloss.Color{
+			"#4B38AE", // deep slate blue
+			"#C0392B", // dark red
+			"#1A8A7D", // dark teal
+			"#B8860B", // dark goldenrod
+			"#7B2D8E", // dark violet
+			"#C0561A", // dark orange
+			"#2E7D32", // dark green
+			"#1A5DB0", // dark blue
+			"#B03060", // dark pink
+			"#007A99", // dark cyan
+			"#9B30FF", // dark fuchsia
+			"#558B2F", // dark lime
+		}
+		t.GlamourStyle = "light"
+	}
+
+	// Build styles from the palette.
+	t.Sidebar = lipgloss.NewStyle().
+		BorderRight(true).
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(t.Secondary)
+
+	t.SidebarItem = lipgloss.NewStyle().
+		Foreground(t.Text).
+		Padding(0, 1)
+
+	t.SidebarUnread = lipgloss.NewStyle().
+		Foreground(t.Text).
+		Bold(true).
+		Padding(0, 1)
+
+	t.SidebarSelected = lipgloss.NewStyle().
+		Foreground(t.Highlight).
+		Background(t.Secondary).
+		Bold(true).
+		Padding(0, 1)
+
+	t.SidebarSection = lipgloss.NewStyle().
+		Foreground(t.Muted).
+		Bold(true).
+		Padding(0, 1)
+
+	t.ChatAuthor = lipgloss.NewStyle().
+		Foreground(t.Primary).
+		Bold(true)
+
+	t.ChatOwnAuthor = lipgloss.NewStyle().
+		Foreground(t.Success).
+		Bold(true)
+
+	t.ChatTimestamp = lipgloss.NewStyle().
+		Foreground(t.Muted)
+
+	t.StatusBar = lipgloss.NewStyle().
+		Foreground(t.Text).
+		Background(t.StatusBg).
+		Padding(0, 1)
+
+	t.StatusConnected = lipgloss.NewStyle().
+		Foreground(t.Success)
+
+	t.ChatSystem = lipgloss.NewStyle().
+		Foreground(t.Muted)
+
+	t.QRTitle = lipgloss.NewStyle().
+		Foreground(t.Primary).
+		Bold(true)
+
+	t.ACSuggestion = lipgloss.NewStyle().
+		Foreground(t.Text).
+		Padding(0, 1)
+
+	t.ACSelected = lipgloss.NewStyle().
+		Foreground(t.Highlight).
+		Background(t.Secondary).
+		Bold(true).
+		Padding(0, 1)
+
+	t.Selection = lipgloss.NewStyle().Reverse(true)
+
+	return t
+}
+
+// resolveTheme checks the config override first, falls back to terminal
+// background detection, and returns a fully built Theme.
+func resolveTheme(cfg Config) Theme {
+	switch cfg.Theme {
+	case "dark":
+		return buildTheme(true)
+	case "light":
+		return buildTheme(false)
+	default: // "auto" or ""
+		return buildTheme(termenv.HasDarkBackground())
 	}
 }
 
-// colorForPubkey derives a stable color from a hex pubkey.
-func colorForPubkey(pubkey string) lipgloss.Color {
-	colors := authorColors
+// colorForPubkey derives a stable color from a hex pubkey using the given
+// author colour palette.
+func colorForPubkey(pubkey string, colors []lipgloss.Color) lipgloss.Color {
 	if len(colors) == 0 {
-		colors = authorColorsDark
+		// Fallback to a hard-coded dark default so we never panic.
+		return lipgloss.Color("#7B68EE")
 	}
 	if len(pubkey) < 2 {
 		return colors[0]
@@ -88,79 +201,6 @@ const (
 	inputMinHeight  = 1
 	inputMaxHeight  = 8
 )
-
-// Styles
-var (
-	sidebarStyle = lipgloss.NewStyle().
-		BorderRight(true).
-		BorderStyle(lipgloss.NormalBorder()).
-		BorderForeground(colorSecondary)
-
-	sidebarItemStyle = lipgloss.NewStyle().
-		Foreground(colorWhite).
-		Padding(0, 1)
-
-	sidebarUnreadStyle = lipgloss.NewStyle().
-		Foreground(colorWhite).
-		Bold(true).
-		Padding(0, 1)
-
-	sidebarSelectedStyle = lipgloss.NewStyle().
-		Foreground(colorHighlight).
-		Background(colorSecondary).
-		Bold(true).
-		Padding(0, 1)
-
-	sidebarSectionStyle = lipgloss.NewStyle().
-		Foreground(colorMuted).
-		Bold(true).
-		Padding(0, 1)
-
-	chatAuthorStyle = lipgloss.NewStyle().
-		Foreground(colorPrimary).
-		Bold(true)
-
-	chatOwnAuthorStyle = lipgloss.NewStyle().
-		Foreground(colorGreen).
-		Bold(true)
-
-	chatTimestampStyle = lipgloss.NewStyle().
-		Foreground(colorMuted)
-
-	statusBarStyle = lipgloss.NewStyle().
-		Foreground(colorWhite).
-		Background(colorStatusBg).
-		Padding(0, 1)
-
-	statusConnectedStyle = lipgloss.NewStyle().
-		Foreground(colorGreen)
-
-	chatSystemStyle = lipgloss.NewStyle().
-		Foreground(colorMuted)
-
-	qrTitleStyle = lipgloss.NewStyle().
-		Foreground(colorPrimary).
-		Bold(true)
-
-	acSuggestionStyle = lipgloss.NewStyle().
-		Foreground(colorWhite).
-		Padding(0, 1)
-
-	acSelectedStyle = lipgloss.NewStyle().
-		Foreground(colorHighlight).
-		Background(colorSecondary).
-		Bold(true).
-		Padding(0, 1)
-)
-
-// detectGlamourStyle queries the terminal background and returns "dark" or "light".
-// Must be called before the TUI starts.
-func detectGlamourStyle() string {
-	if termenv.HasDarkBackground() {
-		return "dark"
-	}
-	return "light"
-}
 
 // newMarkdownRenderer creates a glamour terminal renderer.
 // style should be "dark" or "light" (detected once at startup via detectGlamourStyle).

--- a/ui_test.go
+++ b/ui_test.go
@@ -5,43 +5,43 @@ import (
 )
 
 func TestColorForPubkey(t *testing.T) {
-	initAuthorColors()
+	th := buildTheme(true)
+	colors := th.AuthorColors
+
 	t.Run("deterministic", func(t *testing.T) {
 		pk := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
-		c1 := colorForPubkey(pk)
-		c2 := colorForPubkey(pk)
+		c1 := colorForPubkey(pk, colors)
+		c2 := colorForPubkey(pk, colors)
 		if c1 != c2 {
 			t.Errorf("same key should produce same color: %v != %v", c1, c2)
 		}
 	})
 
-	t.Run("different keys may differ", func(t *testing.T) {
-		// Keys starting with different bytes should (usually) differ.
-		pk1 := "00cdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
-		pk2 := "ffcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
-		// Just verify they don't panic; they might coincide if hash collides.
-		_ = colorForPubkey(pk1)
-		_ = colorForPubkey(pk2)
-	})
-
 	t.Run("short key returns fallback", func(t *testing.T) {
-		c := colorForPubkey("a")
-		if c != authorColors[0] {
-			t.Errorf("expected fallback color %v, got %v", authorColors[0], c)
+		c := colorForPubkey("a", colors)
+		if c != colors[0] {
+			t.Errorf("expected fallback color %v, got %v", colors[0], c)
 		}
 	})
 
 	t.Run("empty key returns fallback", func(t *testing.T) {
-		c := colorForPubkey("")
-		if c != authorColors[0] {
-			t.Errorf("expected fallback color %v, got %v", authorColors[0], c)
+		c := colorForPubkey("", colors)
+		if c != colors[0] {
+			t.Errorf("expected fallback color %v, got %v", colors[0], c)
 		}
 	})
 
 	t.Run("non-hex short key returns fallback", func(t *testing.T) {
-		c := colorForPubkey("zz")
-		if c != authorColors[0] {
+		c := colorForPubkey("zz", colors)
+		if c != colors[0] {
 			t.Errorf("expected fallback color for non-hex, got %v", c)
+		}
+	})
+
+	t.Run("nil colors returns hardcoded fallback", func(t *testing.T) {
+		c := colorForPubkey("ab", nil)
+		if c == "" {
+			t.Error("expected a non-empty fallback color")
 		}
 	})
 }

--- a/view.go
+++ b/view.go
@@ -72,7 +72,7 @@ func (m *model) renderTitleBar() string {
 	if item := m.activeSidebarItem(); item != nil {
 		title = item.Prefix() + item.DisplayName()
 	}
-	return lipgloss.NewStyle().Bold(true).Foreground(colorPrimary).Padding(0, 1).Render(title)
+	return lipgloss.NewStyle().Bold(true).Foreground(m.theme.Primary).Padding(0, 1).Render(title)
 }
 
 func (m *model) updateLayout() {
@@ -143,16 +143,16 @@ func (m *model) updateViewport() {
 	for _, rm := range resolved {
 		msg := rm.msg
 		if msg.Author == "system" {
-			lines = append(lines, chatSystemStyle.Render("  "+msg.Content))
+			lines = append(lines, m.theme.ChatSystem.Render("  "+msg.Content))
 			continue
 		}
 		var authorStyle lipgloss.Style
 		if msg.IsMine {
-			authorStyle = chatOwnAuthorStyle
+			authorStyle = m.theme.ChatOwnAuthor
 		} else if msg.PubKey != "" {
-			authorStyle = lipgloss.NewStyle().Foreground(colorForPubkey(msg.PubKey)).Bold(true)
+			authorStyle = lipgloss.NewStyle().Foreground(colorForPubkey(msg.PubKey, m.theme.AuthorColors)).Bold(true)
 		} else {
-			authorStyle = chatAuthorStyle
+			authorStyle = m.theme.ChatAuthor
 		}
 		displayName := rm.displayName
 		// Right-align the name to the colon (weechat-style).
@@ -161,7 +161,7 @@ func (m *model) updateViewport() {
 		if nameW < maxNameW {
 			namePad = strings.Repeat(" ", maxNameW-nameW)
 		}
-		ts := chatTimestampStyle.Render(msg.Timestamp.Time().Format("15:04"))
+		ts := m.theme.ChatTimestamp.Render(msg.Timestamp.Time().Format("15:04"))
 		author := namePad + authorStyle.Render(displayName)
 		// Convert single newlines to paragraph breaks for glamour,
 		// but leave newlines inside fenced code blocks untouched.
@@ -249,7 +249,7 @@ func (m *model) viewSidebar() string {
 	var items []string
 
 	// CHANNELS section
-	items = append(items, sidebarSectionStyle.Render("CHANNELS"))
+	items = append(items, m.theme.SidebarSection.Render("CHANNELS"))
 	for i, it := range m.sidebar {
 		if it.Kind() != SidebarChannel {
 			break
@@ -259,16 +259,16 @@ func (m *model) viewSidebar() string {
 			name = ansi.Truncate(name, sw-2, "")
 		}
 		if i == m.activeItem {
-			items = append(items, sidebarSelectedStyle.Render(name))
+			items = append(items, m.theme.SidebarSelected.Render(name))
 		} else if m.unread[it.ItemID()] {
-			items = append(items, sidebarUnreadStyle.Render(name))
+			items = append(items, m.theme.SidebarUnread.Render(name))
 		} else {
-			items = append(items, sidebarItemStyle.Render(name))
+			items = append(items, m.theme.SidebarItem.Render(name))
 		}
 	}
 
 	// GROUPS section
-	items = append(items, sidebarSectionStyle.Render("GROUPS"))
+	items = append(items, m.theme.SidebarSection.Render("GROUPS"))
 	for i, it := range m.sidebar {
 		if it.Kind() != SidebarGroup {
 			continue
@@ -278,16 +278,16 @@ func (m *model) viewSidebar() string {
 			name = ansi.Truncate(name, sw-2, "")
 		}
 		if i == m.activeItem {
-			items = append(items, sidebarSelectedStyle.Render(name))
+			items = append(items, m.theme.SidebarSelected.Render(name))
 		} else if m.unread[it.ItemID()] {
-			items = append(items, sidebarUnreadStyle.Render(name))
+			items = append(items, m.theme.SidebarUnread.Render(name))
 		} else {
-			items = append(items, sidebarItemStyle.Render(name))
+			items = append(items, m.theme.SidebarItem.Render(name))
 		}
 	}
 
 	// DMS section
-	items = append(items, sidebarSectionStyle.Render("DMS"))
+	items = append(items, m.theme.SidebarSection.Render("DMS"))
 	for i, it := range m.sidebar {
 		if it.Kind() != SidebarDM {
 			continue
@@ -297,17 +297,17 @@ func (m *model) viewSidebar() string {
 			name = ansi.Truncate(name, sw-2, "")
 		}
 		if i == m.activeItem {
-			items = append(items, sidebarSelectedStyle.Render(name))
+			items = append(items, m.theme.SidebarSelected.Render(name))
 		} else if m.unread[it.ItemID()] {
-			items = append(items, sidebarUnreadStyle.Render(name))
+			items = append(items, m.theme.SidebarUnread.Render(name))
 		} else {
-			items = append(items, sidebarItemStyle.Render(name))
+			items = append(items, m.theme.SidebarItem.Render(name))
 		}
 	}
 
 	content := strings.Join(items, "\n")
 
-	return sidebarStyle.Width(sw).Height(contentHeight).MaxHeight(contentHeight).Render(content)
+	return m.theme.Sidebar.Width(sw).Height(contentHeight).MaxHeight(contentHeight).Render(content)
 }
 
 func (m *model) viewContent() string {
@@ -346,8 +346,8 @@ func (m *model) connectedRelayCount() int {
 func (m *model) viewStatusBar() string {
 	connected := m.connectedRelayCount()
 	total := len(m.relays)
-	bar := statusConnectedStyle.Render(fmt.Sprintf("● %d/%d relays", connected, total))
-	return statusBarStyle.Width(m.width).Render(bar)
+	bar := m.theme.StatusConnected.Render(fmt.Sprintf("● %d/%d relays", connected, total))
+	return m.theme.StatusBar.Width(m.width).Render(bar)
 }
 
 // doubleNewlinesOutsideCode doubles single newlines for markdown paragraph


### PR DESCRIPTION
The core UI colours and lipgloss styles were hardcoded for dark terminals, making the app unreadable on light backgrounds. Author colours and glamour markdown already switched based on termenv.HasDarkBackground(), but the 7 colour constants and 15 style variables did not.

Replace the package-level colour/style vars with a Theme struct that holds both palettes and pre-built styles, selected once at startup via a unified resolveTheme() call. This consolidates the three separate detection points (glamour style, author colours, UI styles) into one.

A "theme" config key ("auto", "dark", "light") lets users override auto-detection for terminals where OSC 11 responses are unreliable, such as tmux without passthrough or SSH sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable theme support with "auto" (terminal auto-detection), "dark", and "light" modes

* **Refactor**
  * Centralized styling system to ensure consistent theme rendering across all UI components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->