### PR TITLE
fix(theme): remove green shades from author palette to avoid collisio…

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -63,12 +63,12 @@ func buildTheme(isDark bool) Theme {
 			"#FFD93D", // gold
 			"#C084FC", // violet
 			"#FF8C42", // orange
-			"#6BCB77", // green
 			"#4D96FF", // blue
 			"#FF6EC7", // hot pink
 			"#00D2FF", // cyan
 			"#E879F9", // fuchsia
-			"#A3E635", // lime
+			"#F5A623", // amber
+			"#7FDBCA", // mint
 		}
 		t.GlamourStyle = "dark"
 	} else {
@@ -86,12 +86,12 @@ func buildTheme(isDark bool) Theme {
 			"#B8860B", // dark goldenrod
 			"#7B2D8E", // dark violet
 			"#C0561A", // dark orange
-			"#2E7D32", // dark green
 			"#1A5DB0", // dark blue
 			"#B03060", // dark pink
 			"#007A99", // dark cyan
 			"#9B30FF", // dark fuchsia
-			"#558B2F", // dark lime
+			"#CC7A00", // dark amber
+			"#1A6B5A", // dark mint
 		}
 		t.GlamourStyle = "light"
 	}


### PR DESCRIPTION
…n with own-author color

In DMs, the peer's name could appear in the same green shade as the user's own name because the author color palette included greens (#6BCB77/#A3E635 dark, #2E7D32/#558B2F light) that were indistinguishable from ChatOwnAuthor (Success color: #9ECE6A/#2E7D32).

The light theme even had the exact same hex value #2E7D32 in both Success and AuthorColors.

Replace the two green palette entries with amber and mint, which are visually distinct from the green own-author style. Add a regression test ensuring no author palette color ever matches the Success color.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Updated the color palette for author identifiers across dark and light themes, replacing green and lime accent colors with new amber and mint variants to enhance visual distinction and consistency throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->