### PR TITLE
nip51: prevent contacts list from losing peers on publish

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -495,7 +495,8 @@ func (m *model) openDM(input string) (tea.Model, tea.Cmd) {
 	}
 	m.updateViewport()
 	if newPeer {
-		return m, publishContactsListCmd(m.pool, m.relays, contactsFromModel(m.allDMPeers(), m.profiles), m.keys, m.kr)
+		m.fetchedContacts[pk] = true
+		return m, publishContactsListCmd(m.pool, m.relays, contactsFromModel(m.allDMPeers(), m.profiles, m.fetchedContacts), m.keys, m.kr)
 	}
 	return m, nil
 }
@@ -554,11 +555,12 @@ func (m *model) leaveCurrentItem() (tea.Model, tea.Cmd) {
 	case DMItem:
 		peer := it.PubKey
 
-		// Remove from sidebar and message history.
+		// Remove from sidebar, message history, and fetched contacts.
 		m.removeSidebarItem(m.activeItem)
 		delete(m.msgs, peer)
+		delete(m.fetchedContacts, peer)
 
-		leaveCmds = append(leaveCmds, publishContactsListCmd(m.pool, m.relays, contactsFromModel(m.allDMPeers(), m.profiles), m.keys, m.kr))
+		leaveCmds = append(leaveCmds, publishContactsListCmd(m.pool, m.relays, contactsFromModel(m.allDMPeers(), m.profiles, m.fetchedContacts), m.keys, m.kr))
 		log.Printf("leaveCurrentItem: left DM with %s", m.resolveAuthor(peer))
 	}
 

--- a/model.go
+++ b/model.go
@@ -113,6 +113,11 @@ type model struct {
 	groupsListTS   nostr.Timestamp
 	nip51Loaded    bool // true after the initial NIP-51 fetch completes
 
+	// fetchedContacts preserves the contacts loaded from the relay so that
+	// publishing never drops peers that are in the relay list but missing
+	// from the sidebar (e.g. due to replay-guard filtering during startup).
+	fetchedContacts map[string]bool // pubkeys from the last NIP-51 contacts fetch
+
 	// Logging
 	logDir string // empty = logging disabled
 }
@@ -279,7 +284,8 @@ func newModel(cfg Config, cfgFlagPath string, keys Keys, pool *nostr.Pool, kr no
 		unread:         make(map[string]bool),
 		localDMEchoes:  make(map[string]time.Time),
 		profiles:       profiles,
-		profilePending: make(map[string]bool),
+		profilePending:  make(map[string]bool),
+		fetchedContacts: make(map[string]bool),
 		lastInputHeight: inputMinHeight,
 		historyIndex:    -1,
 		viewport:       vp,

--- a/model_test.go
+++ b/model_test.go
@@ -542,6 +542,7 @@ func TestContactListWipeOnRestart(t *testing.T) {
 		profilePending:  make(map[string]bool),
 		seenEvents:      make(map[string]time.Time),
 		seenEventsClean: time.Now(),
+		fetchedContacts: make(map[string]bool),
 		dmSeenAtStart:   1000,
 		lastDMSeen:      1000,
 		cfg:             Config{MaxMessages: 100},
@@ -604,17 +605,17 @@ func TestContactListWipeOnRestart(t *testing.T) {
 	}
 
 	// Step 5: Check what contactsFromModel would publish.
-	// On master, this only uses allDMPeers() — the sidebar contents.
-	published := contactsFromModel(m.allDMPeers(), m.profiles)
+	// With the fix, fetchedContacts preserves relay contacts even if they
+	// leave the sidebar.
+	published := contactsFromModel(m.allDMPeers(), m.profiles, m.fetchedContacts)
 	publishedPKs := make(map[string]bool)
 	for _, c := range published {
 		publishedPKs[c.PubKey] = true
 	}
 
-	// BUG: pk_bob was on the relay's NIP-51 list but is no longer in the sidebar.
-	// The published list will NOT contain pk_bob, causing data loss.
+	// pk_bob was on the relay's NIP-51 list; fetchedContacts must preserve it.
 	if !publishedPKs["pk_bob"] {
-		t.Errorf("BUG CONFIRMED: pk_bob was in the NIP-51 contacts list from the relay " +
+		t.Errorf("pk_bob was in the NIP-51 contacts list from the relay " +
 			"but is missing from the published list — contact silently dropped!")
 	}
 

--- a/nip51.go
+++ b/nip51.go
@@ -184,9 +184,26 @@ func parseSimpleGroupsListEvent(evt *nostr.Event) []SavedGroup {
 
 // contactsFromModel converts in-memory DM peer list + profile cache into a
 // []Contact suitable for building a kind 30000 event.
-func contactsFromModel(dmPeers []string, profiles map[string]string) []Contact {
+// fetchedContacts contains pubkeys that were in the relay's contacts list;
+// they are preserved even if they're missing from the sidebar to prevent
+// accidental data loss during startup races.
+func contactsFromModel(dmPeers []string, profiles map[string]string, fetchedContacts map[string]bool) []Contact {
+	seen := make(map[string]bool, len(dmPeers))
 	var contacts []Contact
 	for _, pk := range dmPeers {
+		seen[pk] = true
+		name := shortPK(pk)
+		if n, ok := profiles[pk]; ok && n != "" {
+			name = n
+		}
+		contacts = append(contacts, Contact{Name: name, PubKey: pk})
+	}
+	// Merge contacts that were on the relay but are not currently in the
+	// sidebar (e.g. filtered out by the DM replay guard).
+	for pk := range fetchedContacts {
+		if seen[pk] {
+			continue
+		}
 		name := shortPK(pk)
 		if n, ok := profiles[pk]; ok && n != "" {
 			name = n

--- a/nip51_test.go
+++ b/nip51_test.go
@@ -328,7 +328,7 @@ func TestContactsFromModel(t *testing.T) {
 		"pk3": "charlie",
 	}
 
-	got := contactsFromModel(dmPeers, profiles)
+	got := contactsFromModel(dmPeers, profiles, nil)
 	if len(got) != 3 {
 		t.Fatalf("got %d contacts, want 3", len(got))
 	}
@@ -347,8 +347,33 @@ func TestContactsFromModel(t *testing.T) {
 	}
 }
 
+func TestContactsFromModelMergesFetchedContacts(t *testing.T) {
+	// Simulate: sidebar only has pk1, but pk2 was in the relay's contacts list.
+	// pk2 should be preserved in the output.
+	dmPeers := []string{"pk1"}
+	profiles := map[string]string{
+		"pk1": "alice",
+		"pk2": "bob",
+	}
+	fetched := map[string]bool{"pk1": true, "pk2": true}
+
+	got := contactsFromModel(dmPeers, profiles, fetched)
+	if len(got) != 2 {
+		t.Fatalf("got %d contacts, want 2", len(got))
+	}
+
+	// pk1 from sidebar
+	if got[0].Name != "alice" || got[0].PubKey != "pk1" {
+		t.Errorf("contact[0] = %+v, want {alice, pk1}", got[0])
+	}
+	// pk2 merged from fetched contacts
+	if got[1].Name != "bob" || got[1].PubKey != "pk2" {
+		t.Errorf("contact[1] = %+v, want {bob, pk2}", got[1])
+	}
+}
+
 func TestContactsFromModelEmpty(t *testing.T) {
-	got := contactsFromModel(nil, nil)
+	got := contactsFromModel(nil, nil, nil)
 	if len(got) != 0 {
 		t.Errorf("got %d contacts, want 0", len(got))
 	}

--- a/update.go
+++ b/update.go
@@ -299,7 +299,7 @@ func (m *model) handleDMEvent(msg dmEventMsg) (tea.Model, tea.Cmd) {
 		batchCmds = append(batchCmds, profileCmd)
 	}
 	if newPeer && m.nip51Loaded {
-		batchCmds = append(batchCmds, publishContactsListCmd(m.pool, m.relays, contactsFromModel(m.allDMPeers(), m.profiles), m.keys, m.kr))
+		batchCmds = append(batchCmds, publishContactsListCmd(m.pool, m.relays, contactsFromModel(m.allDMPeers(), m.profiles, m.fetchedContacts), m.keys, m.kr))
 	}
 	if m.dmEvents != nil {
 		batchCmds = append(batchCmds, waitForDMEvent(m.dmEvents, m.keys))
@@ -508,7 +508,7 @@ func (m *model) handleProfileResolved(msg profileResolvedMsg) (tea.Model, tea.Cm
 		m.updateDMItemName(msg.PubKey, msg.DisplayName)
 		m.updateViewport()
 		if m.nip51Loaded {
-			return m, publishContactsListCmd(m.pool, m.relays, contactsFromModel(m.allDMPeers(), m.profiles), m.keys, m.kr)
+			return m, publishContactsListCmd(m.pool, m.relays, contactsFromModel(m.allDMPeers(), m.profiles, m.fetchedContacts), m.keys, m.kr)
 		}
 		return m, nil
 	}
@@ -570,7 +570,10 @@ func (m *model) handleNIP51ListsFetched(msg nip51ListsFetchedMsg) (tea.Model, te
 	if msg.contactsTS > m.contactsListTS && msg.contacts != nil {
 		m.contactsListTS = msg.contactsTS
 		m.replaceDMPeers(msg.contacts)
+		// Remember every contact fetched from the relay so we never
+		// accidentally drop them when publishing an updated list.
 		for _, c := range msg.contacts {
+			m.fetchedContacts[c.PubKey] = true
 			m.profiles[c.PubKey] = c.Name
 		}
 		// Fetch profiles for any new contacts.


### PR DESCRIPTION
No idea if this is the right approach, but somehow restarting nitrous, wiped the contact lists from all relays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves direct-message contacts discovered from relays even if they aren’t currently visible in your sidebar, preventing them from being dropped when publishing or after restart.
  * Ensures removing a DM also clears its fetched state so the contact list stays consistent.

* **Tests**
  * Added tests to verify merged relay-fetched contacts appear in published contact lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->