### PR TITLE
Allow keybinding customization via keybindings.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ See ./config.example.toml for example documentation.
 | `PgDn`      | Scroll down               |
 | `Ctrl+C`    | Quit                      |
 
+Keybindings can be customized in `~/.config/nitrous/keybindings.toml`
+(or set `NITROUS_KEYBINDINGS`). See `keybindings.example.toml` for
+the available actions. Multiple keys per action are supported:
+
+```toml
+prev_room = ["ctrl+up", "alt+k"]
+```
+
 
 | Command                        | Description                                  |
 |--------------------------------|----------------------------------------------|

--- a/config.example.toml
+++ b/config.example.toml
@@ -34,6 +34,10 @@ max_messages = 500
 # logging = true
 # log_dir = "~/.config/nitrous/logs"
 
+# Keybindings — override in a separate file: keybindings.toml
+# (in the same directory as this config, or set NITROUS_KEYBINDINGS).
+# See keybindings.example.toml for available actions and defaults.
+
 # Your Nostr profile (NIP-01 kind 0), published to relays on startup.
 [profile]
 # name = ""

--- a/integration_test.go
+++ b/integration_test.go
@@ -230,7 +230,7 @@ func newTestClient(t *testing.T, name string, relayURL string) *testClient {
 		},
 	})
 
-	m := newModel(cfg, "", keys, pool, &kr, nil, testTheme)
+	m := newModel(cfg, "", keys, pool, &kr, nil, testTheme, DefaultKeyMap())
 
 	tm := teatest.NewTestModel(t, &m,
 		teatest.WithInitialTermSize(120, 40),

--- a/keybindings.example.toml
+++ b/keybindings.example.toml
@@ -1,0 +1,15 @@
+# Keybindings for nitrous. Place this file at:
+#   ~/.config/nitrous/keybindings.toml
+# or set the NITROUS_KEYBINDINGS environment variable.
+#
+# All values are arrays of bubbletea key strings.
+# Omitted keys keep their defaults shown below.
+# Multiple keys per action are supported:
+#   prev_room = ["ctrl+up", "alt+k"]
+
+quit             = ["ctrl+c"]
+prev_room        = ["ctrl+up"]
+next_room        = ["ctrl+down"]
+channel_selector = ["ctrl+k"]
+scroll_up        = ["pgup"]
+scroll_down      = ["pgdown"]

--- a/keymap.go
+++ b/keymap.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+	"github.com/charmbracelet/bubbles/key"
+)
+
+// KeyMap holds the configurable keybindings. Only bindings that commonly
+// conflict with terminal emulators or that users want to remap (e.g. vim-style
+// navigation) are exposed here. Everything else (enter to send, tab for
+// autocomplete, esc to dismiss, up/down in popups) stays hardcoded.
+type KeyMap struct {
+	Quit            key.Binding
+	PrevRoom        key.Binding
+	NextRoom        key.Binding
+	ChannelSelector key.Binding
+	ScrollUp        key.Binding
+	ScrollDown      key.Binding
+}
+
+// DefaultKeyMap returns the default keybindings matching the original
+// hardcoded behavior.
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		Quit: key.NewBinding(
+			key.WithKeys("ctrl+c"),
+			key.WithHelp("ctrl+c", "quit"),
+		),
+		PrevRoom: key.NewBinding(
+			key.WithKeys("ctrl+up"),
+			key.WithHelp("ctrl+up", "previous room"),
+		),
+		NextRoom: key.NewBinding(
+			key.WithKeys("ctrl+down"),
+			key.WithHelp("ctrl+down", "next room"),
+		),
+		ChannelSelector: key.NewBinding(
+			key.WithKeys("ctrl+k"),
+			key.WithHelp("ctrl+k", "channel selector"),
+		),
+		ScrollUp: key.NewBinding(
+			key.WithKeys("pgup"),
+			key.WithHelp("pgup", "scroll up"),
+		),
+		ScrollDown: key.NewBinding(
+			key.WithKeys("pgdown"),
+			key.WithHelp("pgdown", "scroll down"),
+		),
+	}
+}
+
+// keymapTOML is the on-disk representation of user keybinding overrides.
+type keymapTOML struct {
+	Quit            []string `toml:"quit"`
+	PrevRoom        []string `toml:"prev_room"`
+	NextRoom        []string `toml:"next_room"`
+	ChannelSelector []string `toml:"channel_selector"`
+	ScrollUp        []string `toml:"scroll_up"`
+	ScrollDown      []string `toml:"scroll_down"`
+}
+
+// keymapPath returns the path to the keybindings config file.
+func keymapPath(cfgFlagPath string) string {
+	if p := os.Getenv("NITROUS_KEYBINDINGS"); p != "" {
+		return p
+	}
+	dir := filepath.Dir(configPath(cfgFlagPath))
+	return filepath.Join(dir, "keybindings.toml")
+}
+
+// LoadKeyMap reads keybindings from the config file. Missing file returns
+// defaults. Empty arrays for a binding are rejected as errors.
+func LoadKeyMap(cfgFlagPath string) (KeyMap, error) {
+	km := DefaultKeyMap()
+
+	path := keymapPath(cfgFlagPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return km, nil
+		}
+		return km, fmt.Errorf("reading keybindings: %w", err)
+	}
+
+	return ParseKeyMap(data)
+}
+
+// ParseKeyMap parses keybinding overrides from TOML bytes, applying them on
+// top of the defaults.
+func ParseKeyMap(data []byte) (KeyMap, error) {
+	km := DefaultKeyMap()
+
+	var raw keymapTOML
+	if err := toml.Unmarshal(data, &raw); err != nil {
+		return km, fmt.Errorf("parsing keybindings: %w", err)
+	}
+
+	if err := applyOverride(&km.Quit, raw.Quit, "quit"); err != nil {
+		return km, err
+	}
+	if err := applyOverride(&km.PrevRoom, raw.PrevRoom, "prev_room"); err != nil {
+		return km, err
+	}
+	if err := applyOverride(&km.NextRoom, raw.NextRoom, "next_room"); err != nil {
+		return km, err
+	}
+	if err := applyOverride(&km.ChannelSelector, raw.ChannelSelector, "channel_selector"); err != nil {
+		return km, err
+	}
+	if err := applyOverride(&km.ScrollUp, raw.ScrollUp, "scroll_up"); err != nil {
+		return km, err
+	}
+	if err := applyOverride(&km.ScrollDown, raw.ScrollDown, "scroll_down"); err != nil {
+		return km, err
+	}
+
+	return km, nil
+}
+
+// applyOverride replaces a key.Binding's keys if the user provided a
+// non-nil, non-empty override.
+func applyOverride(binding *key.Binding, keys []string, name string) error {
+	if keys == nil {
+		return nil // not specified in config, keep default
+	}
+	if len(keys) == 0 {
+		return fmt.Errorf("keybinding %q: empty key list", name)
+	}
+	help := binding.Help()
+	*binding = key.NewBinding(
+		key.WithKeys(keys...),
+		key.WithHelp(keys[0], help.Desc),
+	)
+	return nil
+}

--- a/keymap_test.go
+++ b/keymap_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestParseKeyMap(t *testing.T) {
+	tomlData := []byte(`
+prev_room = ["alt+k", "ctrl+up"]
+next_room = ["alt+j"]
+`)
+
+	km, err := ParseKeyMap(tomlData)
+	if err != nil {
+		t.Fatalf("ParseKeyMap: %v", err)
+	}
+
+	// Multiple keys per action should all match.
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}, Alt: true}
+	if !key.Matches(msg, km.PrevRoom) {
+		t.Error("PrevRoom should match alt+k after override")
+	}
+	msg = tea.KeyMsg{Type: tea.KeyCtrlUp}
+	if !key.Matches(msg, km.PrevRoom) {
+		t.Error("PrevRoom should also match ctrl+up (multiple keys)")
+	}
+
+	// Non-overridden bindings should keep defaults.
+	msg = tea.KeyMsg{Type: tea.KeyCtrlC}
+	if !key.Matches(msg, km.Quit) {
+		t.Error("Quit should still match ctrl+c (not overridden)")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -76,6 +76,12 @@ func main() {
 	theme := resolveTheme(cfg)
 	mdRender := newMarkdownRenderer(theme.GlamourStyle)
 
+	keymap, err := LoadKeyMap(*configFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "keybindings error: %v\n", err)
+		os.Exit(1)
+	}
+
 	kr := keyer.NewPlainKeySigner(keys.SK)
 
 	pool := nostr.NewPool(nostr.PoolOptions{
@@ -85,7 +91,7 @@ func main() {
 		},
 	})
 
-	m := newModel(cfg, *configFlag, keys, pool, &kr, mdRender, theme)
+	m := newModel(cfg, *configFlag, keys, pool, &kr, mdRender, theme, keymap)
 
 	log.Println("starting TUI")
 	p := tea.NewProgram(&m, tea.WithAltScreen(), tea.WithMouseCellMotion(), tea.WithReportFocus())

--- a/model.go
+++ b/model.go
@@ -27,6 +27,9 @@ type Group struct {
 }
 
 type model struct {
+	// Configurable keybindings
+	keymap KeyMap
+
 	// Theme (dark/light colours and styles)
 	theme Theme
 
@@ -234,7 +237,7 @@ func (m *model) activeSidebarItem() SidebarItem {
 
 
 
-func newModel(cfg Config, cfgFlagPath string, keys Keys, pool *nostr.Pool, kr nostr.Keyer, mdRender *glamour.TermRenderer, theme Theme) model {
+func newModel(cfg Config, cfgFlagPath string, keys Keys, pool *nostr.Pool, kr nostr.Keyer, mdRender *glamour.TermRenderer, theme Theme, keymap KeyMap) model {
 	ta := textarea.New()
 	ta.Placeholder = "Type a message... (/help for commands)"
 	ta.Prompt = "> "
@@ -274,6 +277,7 @@ func newModel(cfg Config, cfgFlagPath string, keys Keys, pool *nostr.Pool, kr no
 	}
 
 	return model{
+		keymap:      keymap,
 		theme:       theme,
 		cfg:         cfg,
 		cfgFlagPath: cfgFlagPath,

--- a/update.go
+++ b/update.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"fiatjaf.com/nostr"
 )
@@ -721,9 +722,9 @@ func (m *model) handleNIP51PublishResult(msg nip51PublishResultMsg) (tea.Model, 
 }
 
 func (m *model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	// Dismiss QR overlay on any key (except ctrl+c which still quits).
+	// Dismiss QR overlay on any key (except quit which still quits).
 	if m.qrOverlay != "" {
-		if msg.String() == "ctrl+c" {
+		if key.Matches(msg, m.keymap.Quit) {
 			m.cancelAllRoomSubs()
 			if m.dmCancel != nil {
 				m.dmCancel()
@@ -868,15 +869,15 @@ func (m *model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	switch msg.String() {
-	case "ctrl+c":
+	switch {
+	case key.Matches(msg, m.keymap.Quit):
 		m.cancelAllRoomSubs()
 		if m.dmCancel != nil {
 			m.dmCancel()
 		}
 		return m, tea.Quit
 
-	case "ctrl+k":
+	case key.Matches(msg, m.keymap.ChannelSelector):
 		// Open channel selector popup
 		m.showChannelSelector = true
 		m.channelSelectorInput = ""
@@ -884,7 +885,7 @@ func (m *model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.updateChannelSelectorItems()
 		return m, nil
 
-	case "ctrl+up":
+	case key.Matches(msg, m.keymap.PrevRoom):
 		total := m.sidebarTotal()
 		if total > 1 {
 			m.activeItem--
@@ -896,7 +897,7 @@ func (m *model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
-	case "ctrl+down":
+	case key.Matches(msg, m.keymap.NextRoom):
 		total := m.sidebarTotal()
 		if total > 1 {
 			m.activeItem++
@@ -908,15 +909,15 @@ func (m *model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
-	case "pgup":
+	case key.Matches(msg, m.keymap.ScrollUp):
 		m.viewport.ScrollUp(10)
 		return m, nil
 
-	case "pgdown":
+	case key.Matches(msg, m.keymap.ScrollDown):
 		m.viewport.ScrollDown(10)
 		return m, nil
 
-	case "enter":
+	case msg.String() == "enter":
 		text := strings.TrimSpace(m.input.Value())
 		if text == "" {
 			return m, nil


### PR DESCRIPTION
Terminal emulators like tmux eat ctrl+up/down, and Mac laptops lack pgup/pgdown, so the hardcoded bindings don't work for everyone. Let users override the 6 navigation/quit bindings in a separate keybindings.toml file alongside config.toml.

Only the bindings that actually conflict with terminals are exposed (quit, prev/next room, channel selector, scroll up/down). Universal UI conventions like enter-to-send and tab-for-autocomplete stay hardcoded since nobody remaps those.

Uses bubbles/key.Binding with key.Matches() for the configurable bindings, keeping string comparisons for the rest. Missing config file means zero-config defaults matching the original behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customizable keybindings system added. Users can now override default keybindings via ~/.config/nitrous/keybindings.toml or the NITROUS_KEYBINDINGS environment variable. Multiple keys can be mapped to the same action.

* **Documentation**
  * Added keybindings customization section to README and example configuration file showing available actions and default key mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->